### PR TITLE
Lifts text-short upper bound (< 0.2)

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -32,6 +32,8 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    build-tools:
+    - hspec-discover
     dependencies:
     - utf8-conversions
     - charsetdetect-ae >= 1.0 && < 1.2

--- a/package.yaml
+++ b/package.yaml
@@ -19,7 +19,7 @@ dependencies:
 - text >=1.0 && <1.3
 - bytestring >=0.10.4 && < 0.11
 - utf8-string >= 1.0 && < 1.2
-- text-short >= 0.1.1 && < 0.1.4
+- text-short >= 0.1.1 && < 0.2
 
 library:
   source-dirs: src

--- a/utf8-conversions.cabal
+++ b/utf8-conversions.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c125a7d35e1048a0b9054a06f2a487647a26869cb5e181121e0eb78fc5ddf431
+-- hash: e18469e1f20c2c3aff82332085eb626b5875a53e45c2df716f47cf63ab724d37
 
 name:           utf8-conversions
 version:        0.1.0.4
@@ -39,7 +39,7 @@ library
       base >=4.7 && <5
     , bytestring >=0.10.4 && <0.11
     , text >=1.0 && <1.3
-    , text-short >=0.1.1 && <0.1.4
+    , text-short >=0.1.1 && <0.2
     , utf8-string >=1.0 && <1.2
   default-language: Haskell2010
 
@@ -58,7 +58,7 @@ test-suite utf8-conversions-test
     , charsetdetect-ae >=1.0 && <1.2
     , hspec >=2.0 && <3.0
     , text >=1.0 && <1.3
-    , text-short >=0.1.1 && <0.1.4
+    , text-short >=0.1.1 && <0.2
     , utf8-conversions
     , utf8-string >=1.0 && <1.2
   default-language: Haskell2010

--- a/utf8-conversions.cabal
+++ b/utf8-conversions.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e18469e1f20c2c3aff82332085eb626b5875a53e45c2df716f47cf63ab724d37
+-- hash: 1d5d8e34ce23d09ca13d0cfffcb1cdf08c24d51161508893e6a78aff036b2069
 
 name:           utf8-conversions
 version:        0.1.0.4
@@ -52,6 +52,8 @@ test-suite utf8-conversions-test
   hs-source-dirs:
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-tool-depends:
+      hspec-discover:hspec-discover
   build-depends:
       base >=4.7 && <5
     , bytestring >=0.10.4 && <0.11


### PR DESCRIPTION
Closes commercialhaskell/stackage#6220.

I've verified (locally) that this change compiles and its test suite passes with `text-short-0.1.4`.